### PR TITLE
Replace run

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -102,8 +102,7 @@ class Installer implements InstallerInterface
         $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         try {
             $process->mustRun();
-            $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
-            $output = explode(PHP_EOL, $process->getOutput());
+            $output = explode("\n", $process->getIncrementalOutput());
             $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
             print_r($output);
             return $output[0];

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -65,7 +65,6 @@ class Installer implements InstallerInterface
         array $executableList = []
     )
     {
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         // Setup
         $this->io = $io;
         $this->remoteFs = $remoteFs;
@@ -96,14 +95,10 @@ class Installer implements InstallerInterface
      */
     public function isInstalled()
     {
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         $process = new Process($this->installedCommand, $this->context->getBinDir());
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         try {
             $process->mustRun();
             $output = explode("\n", $process->getIncrementalOutput());
-            $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
-            print_r($output);
             return $output[0];
         } catch (ProcessFailedException $exception) {
             echo $exception->getMessage();

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -101,9 +101,9 @@ class Installer implements InstallerInterface
         $process = new Process($this->installedCommand, $this->context->getBinDir());
         $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         try {
-            $process->run();
+            $process->mustRun();
             $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
-            $output = explode(PHP_EOL, $process->getIncrementalOutput());
+            $output = explode(PHP_EOL, $process->getOutput());
             $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
             print_r($output);
             return $output[0];

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -65,12 +65,11 @@ class Installer implements InstallerInterface
         array $executableList = []
     )
     {
+        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         // Setup
         $this->io = $io;
         $this->remoteFs = $remoteFs;
         $this->context = $context;
-
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
 
         // Unique values
         $this->installedCommand = (!empty($installedCommand)) ? $installedCommand : ["node", "--version"];

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -97,8 +97,8 @@ class Installer implements InstallerInterface
     {
         $process = new Process($this->installedCommand, $this->context->getBinDir());
         try {
-            $process->mustRun();
-            $output = explode("\n", $process->getIncrementalOutput());
+            $process->run();
+            $output = explode(PHP_EOL, $process->getIncrementalOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             echo $exception->getMessage();

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -98,7 +98,7 @@ class Installer implements InstallerInterface
         $process = new Process($this->installedCommand, $this->context->getBinDir());
         try {
             $process->run();
-            $output = explode(PHP_EOL, $process->getIncrementalOutput());
+            $output = explode("\n", $process->getIncrementalOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             echo $exception->getMessage();

--- a/src/Installer/NodeInstaller.php
+++ b/src/Installer/NodeInstaller.php
@@ -23,7 +23,7 @@ class NodeInstaller extends Installer
         NodeContext $context,
         string $downloadUriTemplate = null
     ) {
-        print_r("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         // Declare download template.
         $downloadUriTemplate = (!empty($downloadUriTemplate)) ? $downloadUriTemplate : 'https://nodejs.org/dist/v${version}/node-v${version}-${osType}-${architecture}.${format}';
 
@@ -43,9 +43,9 @@ class NodeInstaller extends Installer
 
         // Declare command to check if installed.
         $installedCommand = ["node", "--version"];
-        print_r("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         // Initialize object.
         parent::__construct($io, $remoteFs, $context, $downloadUriTemplate, $installedCommand, $executableList);
-        print_r("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
     }
 }

--- a/src/Installer/NodeInstaller.php
+++ b/src/Installer/NodeInstaller.php
@@ -23,7 +23,7 @@ class NodeInstaller extends Installer
         NodeContext $context,
         string $downloadUriTemplate = null
     ) {
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+
         // Declare download template.
         $downloadUriTemplate = (!empty($downloadUriTemplate)) ? $downloadUriTemplate : 'https://nodejs.org/dist/v${version}/node-v${version}-${osType}-${architecture}.${format}';
 
@@ -43,9 +43,8 @@ class NodeInstaller extends Installer
 
         // Declare command to check if installed.
         $installedCommand = ["node", "--version"];
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+
         // Initialize object.
         parent::__construct($io, $remoteFs, $context, $downloadUriTemplate, $installedCommand, $executableList);
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
     }
 }

--- a/src/Installer/YarnInstaller.php
+++ b/src/Installer/YarnInstaller.php
@@ -92,7 +92,7 @@ class YarnInstaller extends Installer
 
         try {
             $process->mustRun();
-            $output = explode(PHP_EOL, $process->getOutput());
+            $output = explode("\n", $process->getIncrementalOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             throw new RuntimeException(sprintf('npm must be installed: %s', $exception->getMessage()));

--- a/src/Installer/YarnInstaller.php
+++ b/src/Installer/YarnInstaller.php
@@ -92,7 +92,7 @@ class YarnInstaller extends Installer
 
         try {
             $process->run();
-            $output = explode(PHP_EOL, $process->getIncrementalOutput());
+            $output = explode("\n", $process->getIncrementalOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             throw new RuntimeException(sprintf('npm must be installed: %s', $exception->getMessage()));

--- a/src/Installer/YarnInstaller.php
+++ b/src/Installer/YarnInstaller.php
@@ -91,8 +91,8 @@ class YarnInstaller extends Installer
         $process = new Process(['npm', 'bin'], $this->context->getBinDir());
 
         try {
-            $process->run();
-            $output = explode(PHP_EOL, $process->getIncrementalOutput());
+            $process->mustRun();
+            $output = explode(PHP_EOL, $process->getOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             throw new RuntimeException(sprintf('npm must be installed: %s', $exception->getMessage()));

--- a/src/Installer/YarnInstaller.php
+++ b/src/Installer/YarnInstaller.php
@@ -91,8 +91,8 @@ class YarnInstaller extends Installer
         $process = new Process(['npm', 'bin'], $this->context->getBinDir());
 
         try {
-            $process->mustRun();
-            $output = explode("\n", $process->getIncrementalOutput());
+            $process->run();
+            $output = explode(PHP_EOL, $process->getIncrementalOutput());
             return $output[0];
         } catch (ProcessFailedException $exception) {
             throw new RuntimeException(sprintf('npm must be installed: %s', $exception->getMessage()));

--- a/src/NodeComposerPlugin.php
+++ b/src/NodeComposerPlugin.php
@@ -37,13 +37,12 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
         $this->io = $io;
 
         $extraConfig = $this->composer->getPackage()->getExtra();
-        $io->write("Before config init");
+
         if (isset($extraConfig['pantheon-se']['node-composer'])) {
             $this->config = Config::fromArray($extraConfig['pantheon-se']['node-composer']);
         } else {
             $this->config = new Config();
         }
-        $io->write("After config init");
     }
 
     /**
@@ -66,13 +65,11 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
      */
     public function onPostUpdate(Event $event)
     {
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         $fs = new RemoteFilesystem($this->io, $this->composer->getConfig());
         $context = new NodeContext(
             $this->composer->getConfig()->get('vendor-dir'),
             $this->composer->getConfig()->get('bin-dir')
         );
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
 
         $nodeInstaller = new NodeInstaller(
             $this->io,
@@ -80,11 +77,10 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
             $context,
             $this->config->getNodeDownloadUrl()
         );
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
 
         $installedNodeVersion = $nodeInstaller->isInstalled();
         $nodeVersion = 'v' . $this->config->getNodeVersion();
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
+
         if (
             $installedNodeVersion === false ||
             strpos($installedNodeVersion, $nodeVersion) === false

--- a/src/NodeComposerPlugin.php
+++ b/src/NodeComposerPlugin.php
@@ -82,9 +82,8 @@ class NodeComposerPlugin implements PluginInterface, EventSubscriberInterface
         );
         $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
 
-        $nodeVersion = 'v' . $this->config->getNodeVersion();
-        $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         $installedNodeVersion = $nodeInstaller->isInstalled();
+        $nodeVersion = 'v' . $this->config->getNodeVersion();
         $this->io->write("Function: " . __FUNCTION__ . " Line: " . __LINE__);
         if (
             $installedNodeVersion === false ||


### PR DESCRIPTION
For some reason, `process->mustRun()` was throwing an array to string error, but doesn't seem to happen with `process->run()`. Swapping out for now.